### PR TITLE
Add priceClass & minimumProtocolVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ custom:
       bucket: my-bucket.s3.amazonaws.com
       prefix: my-prefix
     minimumProtocolVersion: TLSv1.2_2018
+    priceClass: PriceClass_100
 ```
 
 
@@ -364,6 +365,41 @@ custom:
 
 Real world [access log](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html) - out of the box, API Gateway currently does not provide any kind of real "apache-like" access logs for your invocations
          
+---
+
+**priceClass**
+
+_optional_, default: `PriceClass_All`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    priceClass: PriceClass_100
+    ...
+```
+
+CloudFront [PriceClass](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html) - can be PriceClass_All (default), PriceClass_100 or PriceClass_200
+
+---
+
+**minimumProtocolVersion**
+
+_optional_, default: `TLSv1`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    minimumProtocolVersion: TLSv1.2_2018
+    ...
+```
+
+Set minimum SSL/TLS [protocol version](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html#cloudfront-Type-ViewerCertificate-MinimumProtocolVersion) - `TLSv1_2016`, `TLSv1.1_2016`, `TLSv1.2_2018` or `SSLv3`
+
+- The minimum SSL/TLS protocol that CloudFront uses to communicate with viewers
+- The cipher that CloudFront uses to encrypt the content that it returns to viewers
+
 ---
 
 ### Command-line Parameters

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ custom:
     logging:
       bucket: my-bucket.s3.amazonaws.com
       prefix: my-prefix
+    minimumProtocolVersion: TLSv1.2_2018
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -279,6 +279,8 @@ class ServerlessFullstackPlugin {
         this.prepareWaf(distributionConfig);
         this.prepareSinglePageApp(resources.Resources);
         this.prepareS3(resources.Resources);
+        this.prepareMinimumProtocolVersion(distributionConfig);
+
     }
 
     prepareLogging(distributionConfig) {
@@ -347,6 +349,14 @@ class ServerlessFullstackPlugin {
         }
     }
 
+   prepareMinimumProtocolVersion(distributionConfig) {
+    const minimumProtocolVersion = this.getConfig('minimumProtocolVersion', undefined);
+
+    if (minimumProtocolVersion) {
+      distributionConfig.ViewerCertificate.MinimumProtocolVersion = minimumProtocolVersion;
+    }
+  }
+    
     prepareWaf(distributionConfig) {
         const waf = this.getConfig('waf', null);
 


### PR DESCRIPTION
Hi,
Made some changes to align more with `serverless-api-cloudfront`.

Added `priceClass` options to README - as it is implemented in the code - but not documented.

Also added the ability to set `minimumProtocolVersion` by leveraging the functionality implemented by `serverless-api-cloudfront` package.