### PR TITLE
Set the environment variables from the severless template before generating the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,26 @@ class ServerlessFullstackPlugin {
             });
     }
 
+    setEnvironmentVariables() {
+        this.serverless.cli.log('Setting the environment variables');
+        const environment = this.serverless.service.provider.environment;
+
+        if (!environment) {
+          return this.serverless.cli.log(
+            'No environment variables detected. Skipping step...'
+          );
+        }
+
+        Object.keys(environment).forEach(variable => {
+          this.serverless.cli.log(
+            `Setting ${variable} to ${environment[variable]}`
+          );
+          process.env[variable] = environment[variable];
+        });
+    }
+
     generateClient() {
+        this.setEnvironmentVariables();
 
         const clientCommand = this.options.clientCommand;
         const clientSrcPath = this.options.clientSrcPath || '.';

--- a/index.js
+++ b/index.js
@@ -94,27 +94,20 @@ class ServerlessFullstackPlugin {
             });
     }
 
-    setEnvironmentVariables() {
-        this.serverless.cli.log('Setting the environment variables');
-        const environment = this.serverless.service.provider.environment;
+    setClientEnv() {
+        this.serverless.cli.log(`Setting the environment variables...`);
+        const serverlessEnv = this.serverless.service.provider.environment;
 
-        if (!environment) {
+        if (!serverlessEnv) {
           return this.serverless.cli.log(
-            'No environment variables detected. Skipping step...'
+            `No environment variables detected. Skipping step...`
           );
         }
 
-        Object.keys(environment).forEach(variable => {
-          this.serverless.cli.log(
-            `Setting ${variable} to ${environment[variable]}`
-          );
-          process.env[variable] = environment[variable];
-        });
+        return Object.assign({}, process.env, serverlessEnv);
     }
 
     generateClient() {
-        this.setEnvironmentVariables();
-
         const clientCommand = this.options.clientCommand;
         const clientSrcPath = this.options.clientSrcPath || '.';
         if (clientCommand && this.cliOptions['generate-client'] !== false) {
@@ -131,7 +124,8 @@ class ServerlessFullstackPlugin {
 
     performClientGeneration(command, args, clientSrcPath, resolve, reject) {
         this.serverless.cli.log(`Generating client...`);
-        const proc = spawn(command, args, {cwd: clientSrcPath, env: process.env, shell: true});
+        const clientEnv = this.setClientEnv();
+        const proc = spawn(command, args, {cwd: clientSrcPath, env: clientEnv, shell: true});
 
         proc.stdout.on('data', (data) => {
             const printableData = data ? `${data}`.trim() : '';


### PR DESCRIPTION
Issue:

The client cannot get the `process.env` variables defined in the yml file when generating.

``` yaml
# serverless.yml
provider:
  name: aws
  runtime: nodejs8.10
  region: us-east-1
  environment:
    USER_POOL_ID: my_user_pool_id
    USER_POOL_CLIENT_ID: my_user_pool_client_id
```

```javascript
performClientGeneration(command, args, clientSrcPath, resolve, reject) {
    this.serverless.cli.log(`Generating client...`);
    const proc = spawn(command, args, {cwd: clientSrcPath, env: process.env, shell: true});
   
    console.log(process.env.USER_POOL_ID);   // undefined
    console.log(process.env.USER_POOL_CLIENT_ID);   // undefined
    ...
}
```

Excepted results:
```javascript
    console.log(process.env.USER_POOL_ID);   // my_user_pool_id
    console.log(process.env.USER_POOL_CLIENT_ID);   // my_user_pool_client_id
```
