### PR TITLE
New "apiGatewayRestApiId" config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ custom:
     errorDocument: error.html                  # The error document to use
     singlePageApp: false                       # If true 403 errors will be rerouted (missing assets) to your root index document to support single page apps like React and Angular where the js framework handles routing
     compressWebContent: true                   # Use compression when serving web content
-    apiPath: api                               # The path prefix for your API Gateway lambdas. The path for the lambda http event trigger needs to start with this too eg. api/myMethod 
+    apiPath: api                               # The path prefix for your API Gateway lambdas. The path for the lambda http event trigger needs to start with this too eg. api/myMethod
+    apiGatewayRestApiId: a12bc34df5            # If "Api Gateway Rest Api" is not part of the same serverless template, you can set your API id here 
     clientCommand: gulp dist                   # Command to generate the client assets. Defaults to doing nothing
     clientSrcPath: client                      # The path to where you want to run the clientCommand
     waf: 00000000-0000-0000-0000-000000000000  # ID of the Web Application Firewall. Defaults to not used
@@ -175,6 +176,23 @@ functions:
         method: post
         integration: lambda
 ```
+
+---
+
+**apiGatewayRestApiId**
+
+_optional_, default: `not set`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    apiGatewayRestApiId: a12bc34df5
+    ...
+```
+
+This is only needed if "Api Gateway Rest Api" is not part of the same serverless template and the API id is not defined in [provider -> apiGateway](https://serverless.com/framework/docs/providers/aws/events/apigateway/#share-api-gateway-and-api-resources) section.
+The id can be found in API Gateway url. For example, if your Rest API url is `https://a12bc34df5.execute-api.eu-central-1.amazonaws.com`, API id will be `a12bc34df5`. 
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -241,18 +241,52 @@ class ServerlessFullstackPlugin {
     checkForApiGataway() {
         const baseResources = this.serverless.service.provider.compiledCloudFormationTemplate;
         const apiGatewayConfig = baseResources.Resources.ApiGatewayRestApi;
-        if (!apiGatewayConfig) {
-            this.serverless.cli.log(`ApiGatewayRestApi not found, removing orgin from CloudFront...`);
-            const distributionConfig = baseResources.Resources.ApiDistribution.Properties.DistributionConfig;
-            distributionConfig.Origins = _.filter(distributionConfig.Origins, (origin => {
-                return origin.Id !== 'ApiGateway';
-            }));
-            distributionConfig.CacheBehaviors = _.filter(distributionConfig.CacheBehaviors, (cacheBehavior => {
-                return cacheBehavior.TargetOriginId !== 'ApiGateway';
-            }));
+
+        if (!apiGatewayConfig && !this.setApiGatewayIdFromConfig(baseResources)) {
+            this.removeApiGatewayOrigin(baseResources);
         }
 
         return baseResources;
+    }
+
+    removeApiGatewayOrigin(baseResources) {
+        this.serverless.cli.log(`ApiGatewayRestApi not found, removing orgin from CloudFront...`);
+        const distributionConfig = baseResources.Resources.ApiDistribution.Properties.DistributionConfig;
+        distributionConfig.Origins = _.filter(distributionConfig.Origins, (origin => {
+            return origin.Id !== 'ApiGateway';
+        }));
+        distributionConfig.CacheBehaviors = _.filter(distributionConfig.CacheBehaviors, (cacheBehavior => {
+            return cacheBehavior.TargetOriginId !== 'ApiGateway';
+        }));
+    }
+
+    setApiGatewayIdFromConfig(baseResources) {
+        const restApiId = this.getRestApiId();
+
+        if (!restApiId) {
+            return false;
+        }
+
+        const distributionConfig = baseResources.Resources.ApiDistribution.Properties.DistributionConfig;
+        const apiOrigin = distributionConfig.Origins.find(origin => origin.Id === 'ApiGateway');
+
+        apiOrigin.DomainName = {
+            'Fn::Join': ['', [restApiId, '.execute-api.', {
+                Ref: 'AWS::Region'
+            }, '.amazonaws.com']]
+        };
+
+        return true;
+    }
+
+    getRestApiId() {
+        const apiGatewaySection = this.serverless.service.provider.apiGateway;
+
+        if (apiGatewaySection && apiGatewaySection.restApiId) {
+            return apiGatewaySection.restApiId;
+        }
+
+        return this.getConfig('apiGatewayRestApiId', null);
     }
 
     printSummary() {


### PR DESCRIPTION
The plugin can now get Rest Api Id from two more places:
```yml
custom:
  fullstack:
    apiGatewayRestApiId: a12bc34df5
```
```yml
provider:
  apiGateway:
    restApiId:
      'Fn::ImportValue': ApiGateway-restApiId
```

Closes #11 