### PR TITLE
Add configuration to support CloudFront Restricted Views

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,6 +333,7 @@ class ServerlessFullstackPlugin {
         this.prepareCertificate(distributionConfig);
         this.prepareWaf(distributionConfig);
         this.prepareSinglePageApp(resources.Resources);
+        this.prepareRestrictedPaths(distributionConfig);
         this.prepareS3(resources.Resources);
         this.prepareMinimumProtocolVersion(distributionConfig);
         this.prepareCompressWebContent(distributionConfig);
@@ -480,6 +481,28 @@ class ServerlessFullstackPlugin {
                     }
                 }
             }
+        }
+    }
+
+    prepareRestrictedPaths(distributionConfig) {
+        const restrictedPaths = this.getConfig('restrictedPaths', null);
+
+        const behaviorTemplate = _.find(distributionConfig.CacheBehaviors, (cacheBehavior => {
+            return cacheBehavior.TargetOriginId === 'RestrictedPathTemplate';
+        }));
+
+        //Remove template
+        distributionConfig.CacheBehaviors = _.filter(distributionConfig.CacheBehaviors, (cacheBehavior => {
+            return cacheBehavior.TargetOriginId !== 'RestrictedPathTemplate';
+        }));
+
+        if (restrictedPaths !== null) {
+            this.serverless.cli.log(`Configuring distribution for restricted paths...`);
+            distributionConfig.CacheBehaviors = distributionConfig.CacheBehaviors
+                .concat(_.map(restrictedPaths, (restrictedPath) => {
+                    return { ...behaviorTemplate, ...restrictedPath, TargetOriginId: 'WebApp',
+                        TrustedSigners: [].concat(restrictedPath.TrustedSigners) };
+                }));
         }
     }
 

--- a/lib/resources/resources.yml
+++ b/lib/resources/resources.yml
@@ -136,6 +136,21 @@ Resources:
             TargetOriginId: ApiGateway
             ViewerProtocolPolicy: https-only
             PathPattern: api/*
+          - AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            ## Compress web content: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html
+            Compress: true
+            ## The origin id defined above
+            TargetOriginId: RestrictedPathTemplate
+            ## Defining if and how the QueryString and Cookies are forwarded to the origin which in this case is S3
+            ForwardedValues:
+              QueryString: 'false'
+              Cookies:
+                Forward: none
+            ## The protocol that users can use to access the files in the origin. To allow HTTP use `allow-all`
+            ViewerProtocolPolicy: redirect-to-https
         ViewerCertificate:
           AcmCertificateArn: arn
           SslSupportMethod: sni-only


### PR DESCRIPTION
I added an option to add additional restricted behaviors to directory paths in S3. This allows one to create generated content and host under their domain that needs to be restricted by CloudFront's signing of URL's or signing of cookies while keeping parts of the website public.

Below is an example of the new configurable variables.

```
custom:
  fullstack:
    restrictedPaths:
      - PathPattern: path/*
        TrustedSigners:
          - self
```