### PR TITLE
Add "noConfirm" flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ custom:
       prefix: my-prefix
     minimumProtocolVersion: TLSv1.2_2018
     priceClass: PriceClass_100
+    noConfirm: false                           # Alternative to --no-confirm flag. Use this parameter if you do not want a confirmation prompt to interrupt automated builds.
 ```
 
 
@@ -434,6 +435,22 @@ Set minimum SSL/TLS [protocol version](https://docs.aws.amazon.com/cloudfront/la
 
 - The minimum SSL/TLS protocol that CloudFront uses to communicate with viewers
 - The cipher that CloudFront uses to encrypt the content that it returns to viewers
+
+---
+
+**noConfirm**
+
+_optional_, default: `false`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    noConfirm: true
+    ...
+```
+
+Use this parameter if you do not want a confirmation prompt to interrupt automated builds. If either this or `--no-confirm` CLI parameter is true the confirmation prompt will be disabled. 
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class ServerlessFullstackPlugin {
         return this.validateConfig()
             .then(() => {
                 bucketName = this.getBucketName(this.options.bucketName);
-                return this.cliOptions.confirm === false ? true : new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
+                return (this.cliOptions.confirm === false || this.options.noConfirm === true) ? true : new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
             })
             .then(goOn => {
                 if (goOn) {
@@ -186,7 +186,7 @@ class ServerlessFullstackPlugin {
                 );
 
                 deployDescribe.forEach(m => this.serverless.cli.log(m));
-                return this.cliOptions.confirm === false ? true : new Confirm(`Do you want to proceed?`).run();
+                return (this.cliOptions.confirm === false || this.options.noConfirm === true) ? true : new Confirm(`Do you want to proceed?`).run();
             })
             .then(goOn => {
                 if (goOn) {


### PR DESCRIPTION
For example on Serverless Frameworks' CI/CD pipeline, it's not possible to define CLI parameters for deployment and it will always run `sls deploy` command. This means that client deployment will hang on the confirmation prompt. This commit adds the possibility to define `noConfirm` in serverless.yml, enabling builds on https://dashboard.serverless.com .