### PR TITLE
Add option for custom invalidation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `invalidationPaths` setting to allow defining custom invalidation paths for the cloudfront distribution
+
 ## [0.7.1] - 2020-3-18
 Thanks @artoliukkonen
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ custom:
     indexDocument: index.html                  # The index document to use
     errorDocument: error.html                  # The error document to use
     singlePageApp: false                       # If true 403 errors will be rerouted (missing assets) to your root index document to support single page apps like React and Angular where the js framework handles routing
+    invalidationPaths:                         # Custom invalidationPaths for cloudfront in case your frontend framework uses filename hashing
+      - /index.html
+      - /error.html
     compressWebContent: true                   # Use compression when serving web content
     apiPath: api                               # The path prefix for your API Gateway lambdas. The path for the lambda http event trigger needs to start with this too eg. api/myMethod
     apiGatewayRestApiId: a12bc34df5            # If "Api Gateway Rest Api" is not part of the same serverless template, you can set your API id here 
@@ -321,6 +324,24 @@ If true 403 errors will be rerouted (missing assets) to your root index document
     
 ---
 
+**invalidationPaths**
+
+_optional_, default: `['/*']`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    invalidationPaths:
+      - /index.html
+      - /error.html
+    ...
+```
+
+Custom invalidationPaths for cloudfront in case your frontend framework uses filename hashing
+    
+---
+
 **compressWebContent**
 
 _optional_, default: `true`
@@ -516,6 +537,7 @@ Use this parameter if you do not want to invalidate the CloudFront distribution.
 - [haochang](https://github.com/haochang)
 - [hakimio](https://github.com/hakimio)
 - [artoliukkonen](https://github.com/artoliukkonen)
+- [pecirep](https://github.com/pecirep)
 
 ## Credits
 Forked from the [**serverless-api-cloudfront**](https://github.com/Droplr/serverless-api-cloudfront/)  

--- a/index.js
+++ b/index.js
@@ -155,7 +155,8 @@ class ServerlessFullstackPlugin {
             bucketName,
             headerSpec,
             indexDoc,
-            errorDoc;
+            errorDoc,
+            invalidationPaths;
 
         return this.validateConfig()
             .then(() => {
@@ -175,6 +176,14 @@ class ServerlessFullstackPlugin {
                 headerSpec = this.options.objectHeaders;
                 indexDoc = this.options.indexDocument || "index.html";
                 errorDoc = this.options.errorDocument || "error.html";
+                invalidationPaths = this.options.invalidationPaths || ['/*'];
+
+                if (!Array.isArray(invalidationPaths)) {
+                    invalidationPaths = [invalidationPaths];
+                }
+                
+                //paths must start with '/'
+                invalidationPaths = invalidationPaths.map(path => path[0] === '/' ? path : '/' + path);
 
                 const deployDescribe = ['This deployment will:'];
 
@@ -225,7 +234,7 @@ class ServerlessFullstackPlugin {
                 if (this.cliOptions['invalidate-distribution'] === false) {
                     this.serverless.cli.log(`Skipping cloudfront invalidation...`);
                 } else {
-                    return invalidateCloudfrontDistribution(this.serverless);
+                    return invalidateCloudfrontDistribution(this.serverless, invalidationPaths);
                 }
             })
             .catch(error => {

--- a/lib/cloudFront.js
+++ b/lib/cloudFront.js
@@ -10,7 +10,7 @@ const getCloudFrontDistributionId = async (serverless) => {
     return !apiDistribution ? null : apiDistribution.PhysicalResourceId;
 };
 
-const invalidateCloudfrontDistribution = async (serverless) => {
+const invalidateCloudfrontDistribution = async (serverless, invalidationPaths) => {
     const distributionId = await getCloudFrontDistributionId(serverless);
 
     if (!distributionId) {
@@ -24,8 +24,8 @@ const invalidateCloudfrontDistribution = async (serverless) => {
             InvalidationBatch: {
                 CallerReference: Date.now().toString(),
                 Paths: {
-                    Quantity: 1,
-                    Items: ['/*']
+                    Quantity: invalidationPaths.length,
+                    Items: invalidationPaths
                 }
             }
         },


### PR DESCRIPTION
Some SPAs (like Vue.js) hash their filenames by default to improve caching, therefore invalidating the entire distribution is not necessary and can incur charges if there are a lot of cached static assets being invalidated on every deployment.
A custom invalidation path solves this without adding breaking changes/complexity as  `'/*'` is still the default.
I'm already using this in a production environment so maybe this simple addition can be useful for others as well.