### PR TITLE
Custom origins and cachebehaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add `invalidationPaths` setting to allow defining custom invalidation paths for the cloudfront distribution
+- Add `origins` setting to allow adding additional distribution origins in the form of CloudFormation resources
+- Add `cacheBehaviors` setting to allow adding additional distribution cache behaviors in the form of CloudFormation resources
 
 ## [0.7.1] - 2020-3-18
 Thanks @artoliukkonen

--- a/README.md
+++ b/README.md
@@ -475,6 +475,67 @@ Use this parameter if you do not want a confirmation prompt to interrupt automat
 
 ---
 
+**origins**
+
+_optional_, default: `not set`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    origins:
+      - Id: Media
+        DomainName: 
+          Fn::GetAtt:
+            - MediaBucket
+            - DomainName
+        S3OriginConfig:
+          OriginAccessIdentity:
+            Fn::Join:
+              - ''
+              - - origin-access-identity/cloudfront/
+                - { Ref: S3OriginAccessIdentity }
+    ...
+```
+
+Use this parameter if you want to add additional origins to the CloudFormation resources.
+
+---
+
+**cacheBehaviors**
+
+_optional_, default: `not set`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    cacheBehaviors:
+      - TargetOriginId: Media
+        PathPattern: media/*
+        AllowedMethods:
+          - GET
+          - HEAD
+          - OPTIONS
+        CachedMethods:
+          - HEAD
+          - GET
+        ForwardedValues:
+          QueryString: true
+          Headers:
+            - Accept
+            - Referer
+            - Authorization
+            - Content-Type
+        ViewerProtocolPolicy: redirect-to-https
+        ...
+    ...
+```
+
+Use this parameter if you want to add additional cache behaviors to the CloudFormation resources.
+
+---
+
 ### Command-line Parameters
 
 

--- a/index.js
+++ b/index.js
@@ -386,6 +386,13 @@ class ServerlessFullstackPlugin {
                 origin.OriginPath = `/${this.getStage()}`;
             }
         }
+        
+        const customOrigins = this.getConfig('origins', null);
+        if (customOrigins) {
+            distributionConfig.Origins.push(
+                ...customOrigins
+            );
+        }
     }
 
     preparePathPattern(distributionConfig) {
@@ -395,6 +402,13 @@ class ServerlessFullstackPlugin {
             if (cacheBehavior.TargetOriginId === 'ApiGateway') {
                 cacheBehavior.PathPattern = `${apiPath}/*`;
             }
+        }
+        
+        const customCacheBehaviors = this.getConfig('cacheBehaviors', null);
+        if (customCacheBehaviors) {
+            distributionConfig.CacheBehaviors.push(
+                ...customCacheBehaviors
+            );
         }
     }
 


### PR DESCRIPTION
Just a small, simple feature to allow adding further origins and cache behaviors to the cloudfront distribution, for situations where there might be a separate bucket containing media or user generated data, with a corresponding path (and many other use-cases, really). So far you'd have to copy the entire Distribution resource to the serverless config and add the changes there, this should make it a bit more elegant.
Hot tip: use external files and reference them in the serverless.yml:
`origins: ${file(./resources/customCloudfront.yml):Origins}`
