### PR TITLE
WIP: Add route53 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `route53` config parameter to manage domains and certifiacte automatically using route53
 
 ## [0.8.0] - 2021-1-28
 Thanks @pecirep, @miguel-a-calles-mba, @superandrew213

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ custom:
   fullstack:
     domain: my-custom-domain.com
     certificate: arn:aws:acm:us-east-1:...     # The ARN for the SSL cert to use form AWS CertificateManager
+    route53: false                             # Use route53 to manage domains and certificate
     bucketName: webapp-deploy                  # Unique name for the S3 bucket to host the client assets
     distributionFolder: client/dist            # Path to the client assets to be uploaded to S3
     indexDocument: index.html                  # The index document to use
@@ -256,6 +257,24 @@ custom:
 ```
 
 The custom domain for your fullstack serverless app.
+
+---
+
+**route53**
+
+_optional_, default: `false`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    route53: true
+    ...
+```
+
+Use this parameter if you want the plugin to manage domains via route53, including automatic SSL certificate creation and validation through ACM (this means you can omit the `certificateArn` parameter).
+
+If one or more domains aren't managed by a Hosted Zone in your account, the required DNS entries will be written to the console.
 
 ---
 

--- a/lib/resources/templates.yml
+++ b/lib/resources/templates.yml
@@ -1,0 +1,26 @@
+Route53AliasTemplate:
+  Type: AWS::Route53::RecordSetGroup
+  Properties:
+    HostedZoneId: hostedZoneId
+    RecordSets:
+      - Name: domain.tld
+        Type: A
+        AliasTarget:
+          HostedZoneId: Z2FDTNDATAQYW2 # The static CloudFront Hosted Zone ID
+          DNSName:
+            Fn::GetAtt: ["ApiDistribution", "DomainName"]
+          EvaluateTargetHealth: false
+      # ...
+
+CertTemplate:
+  Type: AWS::CertificateManager::Certificate
+  Properties:
+    DomainName: domain.tld
+    DomainValidationOptions:
+      # - DomainName: domain.tld
+      #   HostedZoneId: hostedZoneId
+      # - DomainName: example.com
+      #   ValidationDomain: example.com
+      # ...
+    ValidationMethod: DNS
+    # SubjectAlternativeNames:

--- a/lib/route53.js
+++ b/lib/route53.js
@@ -1,0 +1,18 @@
+// get hosted zones, group domains by HZ.Id using .reduce and extract values
+const groupDomainsByHostedZone = async (serverless, domains) => {
+    const r53response = await serverless.getProvider('aws').request('Route53', 'listHostedZones', {});
+    // we only want raw Ids
+    const hostedZones = r53response.HostedZones.map(hz => ({...hz, Id: hz.Id.split("/").reverse()[0]}));
+
+    const hostedZoneMap = domains.reduce((accumulator, domain) => {
+        const hostedZone = hostedZones.find(hostedZone => `${domain}.`.includes(hostedZone.Name));
+        if (accumulator[hostedZone?.Id]) accumulator[hostedZone?.Id].domains.push(domain);
+        else accumulator[hostedZone?.Id] = {...hostedZone, domains: [domain]};
+        return accumulator;
+    }, {});
+    return Object.values(hostedZoneMap);
+}
+
+module.exports = {
+    groupDomainsByHostedZone
+};


### PR DESCRIPTION
Disclaimer: While this branch "works", it is not yet suited for production

Introduces automated domain management using route53, including automated SSL certificate requests and validations.
If one or more domains aren't managed by a Hosted Zone in your account, the required DNS entries will be written to the console.
If there is no issued SSL certificate for all domains combined and one or more aren't managed by a Hosted Zone in your account, deployment will wait for the DNS entries to be added manually and the certificate to be issued.

I'm already using this in a project and have done some testing, but it would be a great if a few more people could try it out and provide feedback. I also need feedback/input for the following problems:
 - currently there is no cleanup. if the stack is remove the certificates won't be deleted, neither will the domains. I'm wondering how best to approach this to make sure certificates and DNS entries that weren't created by the plugin for this stack aren't deleted as well. Should I add tags/comments to thsoe resources and only delete resources that have the tags? doesn't seem like a particularly elegant, as one could have 2 domains in the stack initially, then remove one from the config and then delete the stack. to delete the removed domain and it's cert as well all DNS entries and certs in the account would have to be queried for the tags... maybe someone has a better idea.
 - should certificate requests just be done automatically if the parameter isn't set in the config but a domain is defined? The plugin would output the necessary domains to the console and wait for it to be issued. currently this is only done if the route53 parameter is set to true.

All suggestions are welcome, I think this would be a nice addition to the plugin if done properly.