### PR TITLE
empty bucket with more then 1000 items

### DIFF
--- a/lib/bucketUtils.js
+++ b/lib/bucketUtils.js
@@ -54,7 +54,7 @@ function emptyBucket(aws, bucketName) {
         const contents = resp.Contents;
 
         if (!contents[0]) {
-            return BbPromise.resolve();
+        return BbPromise.resolve(true);
         } else {
             const objects = _.map(contents, function (content) {
                 return _.pick(content, 'Key');
@@ -67,6 +67,10 @@ function emptyBucket(aws, bucketName) {
 
             return aws.request('S3', 'deleteObjects', params);
         }
+    })
+    .then(function (result) {
+      if (result === true) return BbPromise.resolve();
+      else return emptyBucket(aws, bucketName);
     });
 }
 


### PR DESCRIPTION
As described in issue https://github.com/MadSkills-io/fullstack-serverless/issues/38 `emptyBucket` does not delete all items if there are more then 1000 items in the bucket.

I'm more familliar with typescript with async await so maybe my code is not optimal. Fell free to adapt it. 