### PR TITLE
Provide Example for Automatic Route53 Alias Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 package-lock.json
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Add documentation for how to automatically configure Route53 Aliases using provided CloudFormation Template
 
 ## [0.8.0] - 2021-1-28
 Thanks @pecirep, @miguel-a-calles-mba, @superandrew213

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install --save-dev fullstack-serverless
 * All fullstack-serverless configuration parameters are optional - e.g. don't provide ACM Certificate ARN
   to use default CloudFront certificate (which works only for default cloudfront.net domain).
 * This plugin **does not create Route53 aliases** for the newly created CloudFront distribution automatically;
-  however, this is easily configured with the addition of a `AWS::Route53::RecordSetGroup` CloudFormation templating (provided below). 
+  however, this is easily configured with the addition of `AWS::Route53::RecordSetGroup` CloudFormation templating (provided below). 
   Alternatively, you may manually add Route53 ALIAS record pointing to your CloudFront domain name in the AWS console.
 * First deployment may be quite long (e.g. 10 min) as Serverless is waiting for
   CloudFormation to deploy CloudFront distribution.


### PR DESCRIPTION
I've provided documentation on how to get Route53 to automatically create an Alias (or Aliases) for a domain in an existing Hosted Zone. This alias is automatically created on `sls deploy` and is removed on `sls remove` and requires no code changes to the plugin code. This would probably be nice to have built-in to the plugin natively, which I could probably add at a later time, but I figured it would probably be nice to have some documentation on how to programmatically add the aliases in the `serverless.yml` without having to do it manually in the mean time.