### PR TITLE
Added flag to prevent prefixing bucketName

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ custom:
     domain: my-custom-domain.com
     certificate: arn:aws:acm:us-east-1:...     # The ARN for the SSL cert to use form AWS CertificateManager
     bucketName: webapp-deploy                  # Unique name for the S3 bucket to host the client assets
+    omitBucketPrefix: false                    # If 'true', will not prefix bucketName with `${self:service}-${self:provider.stage}-`
     distributionFolder: client/dist            # Path to the client assets to be uploaded to S3
     indexDocument: index.html                  # The index document to use
     errorDocument: error.html                  # The error document to use
@@ -134,6 +135,22 @@ custom:
 ```
 
 Use this parameter to specify a unique name for the S3 bucket that your files will be uploaded to.
+
+---
+
+**omitBucketPrefix**
+
+_optional_, default: `false`
+
+```yaml
+custom:
+  fullstack:
+    ...
+    omitBucketPrefix: false
+    ...
+```
+
+Set this parameter to `true` to create an S3 bucket that precisely matches `bucketName` without the {service}-{stage} prefix
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ class ServerlessFullstackPlugin {
 
         return this.validateConfig()
             .then(() => {
-                bucketName = this.getBucketName(this.options.bucketName);
+                bucketName = this.getBucketName(this.options.bucketName, this.options.omitBucketPrefix);
                 return (this.cliOptions.confirm === false || this.options.noConfirm === true) ? true : new Confirm(`Are you sure you want to delete bucket '${bucketName}'?`).run();
             })
             .then(goOn => {
@@ -174,7 +174,7 @@ class ServerlessFullstackPlugin {
 
                     distributionFolder = this.options.distributionFolder || path.join('client/dist');
                     clientPath = path.join(this.serverless.config.servicePath, distributionFolder);
-                    bucketName = this.getBucketName(this.options.bucketName);
+                    bucketName = this.getBucketName(this.options.bucketName, this.options.omitBucketPrefix);
                     headerSpec = this.options.objectHeaders;
                     indexDoc = this.options.indexDocument || "index.html";
                     errorDoc = this.options.errorDocument || "error.html";
@@ -513,9 +513,10 @@ class ServerlessFullstackPlugin {
 
     prepareS3(resources) {
         const bucketName = this.getConfig('bucketName', null);
+        const omitBucketPrefix = this.getConfig('omitBucketPrefix', false);
 
         if (bucketName !== null) {
-            const stageBucketName = this.getBucketName(bucketName);
+            const stageBucketName = this.getBucketName(bucketName, omitBucketPrefix);
             this.serverless.cli.log(`Setting up '${stageBucketName}' bucket...`);
             resources.WebAppS3Bucket.Properties.BucketName = stageBucketName;
             resources.WebAppS3BucketPolicy.Properties.Bucket = stageBucketName;
@@ -544,8 +545,8 @@ class ServerlessFullstackPlugin {
         );
     }
 
-    getBucketName(bucketName) {
-        const stageBucketName = `${this.serverless.service.service}-${this.getStage()}-${bucketName}`;
+    getBucketName(bucketName, omitBucketPrefix) {
+        const stageBucketName = omitBucketPrefix ? bucketName : `${this.serverless.service.service}-${this.getStage()}-${bucketName}`;
         return stageBucketName;
     }
 


### PR DESCRIPTION
This branch adds a flag `omitBucketPrefix`, which will allow applications to specify and express their own concepts for schema/convention with the `bucketName` field.