### PR TITLE
Add serverless v3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,20 @@ echo "error page" >> client/dist/error.html
 
 **Third**, run the plugin (this can take several minutes the first time), and visit your new website!
 
+Serverless v2 cli params
+
 ```bash
 serverless deploy [--no-delete-contents] [--no-generate-client]
+```
+
+Serverless v3 cli params
+
+> Serverless v3 forbids free-form cli options.  
+> Therefore options can now only be passed as `--param="option=value"`.  
+> For the sake of simplicity, all v2 options are still available and passable through the `param` argument.  
+
+```bash
+serverless deploy [--param="no-delete-contents"] [--param="generate-client"]
 ```
 
 The plugin should output the location of your newly deployed static site to the console.

--- a/index.js
+++ b/index.js
@@ -50,6 +50,18 @@ class ServerlessFullstackPlugin {
                 }
             }
         };
+
+        // Serverless v3 hotfix/compat.
+        // @note; Better refactor all the cliOptions getters below instead
+        const isv3 = this.serverless.version.split('.')[0] === '3';
+        if (isv3) {
+          const _cliOptions = [...this.cliOptions.param];
+          _cliOptions.forEach((k) => {
+            const key = k.replace('no-', '');
+            const val = !k.includes('no');
+            this.cliOptions[key] = val;
+          });
+        }
     }
 
     validateConfig() {

--- a/index.js
+++ b/index.js
@@ -50,18 +50,6 @@ class ServerlessFullstackPlugin {
                 }
             }
         };
-
-        // Serverless v3 hotfix/compat.
-        // @note; Better refactor all the cliOptions getters below instead
-        const isv3 = this.serverless.version.split('.')[0] === '3';
-        if (isv3) {
-          const _cliOptions = [...this.cliOptions.param];
-          _cliOptions.forEach((k) => {
-            const key = k.replace('no-', '');
-            const val = !k.includes('no');
-            this.cliOptions[key] = val;
-          });
-        }
     }
 
     validateConfig() {
@@ -123,7 +111,7 @@ class ServerlessFullstackPlugin {
     generateClient() {
         const clientCommand = this.options.clientCommand;
         const clientSrcPath = this.options.clientSrcPath || '.';
-        if (clientCommand && this.cliOptions['generate-client'] !== false) {
+        if (clientCommand && this.getCLIOptions('generate-client') !== false) {
             const args = clientCommand.split(' ');
             const command = args.shift();
             return new BbPromise(this.performClientGeneration.bind(this, command, args, clientSrcPath));
@@ -162,7 +150,7 @@ class ServerlessFullstackPlugin {
 
     processDeployment() {
 
-        if(this.cliOptions['client-deploy'] !== false) {
+        if(this.getCLIOptions('client-deploy') !== false) {
             let region,
                 distributionFolder,
                 clientPath,
@@ -201,7 +189,7 @@ class ServerlessFullstackPlugin {
 
                     const deployDescribe = ['This deployment will:'];
 
-                    if (this.cliOptions['delete-contents'] !== false) {
+                    if (this.getCLIOptions('delete-contents') !== false) {
                         deployDescribe.push(`- Remove all existing files from bucket '${bucketName}'`);
                     }
                     deployDescribe.push(
@@ -219,7 +207,7 @@ class ServerlessFullstackPlugin {
                             .then(exists => {
                                 if (exists) {
                                     this.serverless.cli.log(`Bucket found...`);
-                                    if (this.cliOptions['delete-contents'] === false) {
+                                    if (this.getCLIOptions('delete-contents') === false) {
                                         this.serverless.cli.log(`Keeping current bucket contents...`);
                                         return BbPromise.resolve();
                                     }
@@ -245,7 +233,7 @@ class ServerlessFullstackPlugin {
                     return BbPromise.resolve();
                 })
                 .then(() => {
-                    if (this.cliOptions['invalidate-distribution'] === false) {
+                    if (this.getCLIOptions('invalidate-distribution') === false) {
                         this.serverless.cli.log(`Skipping cloudfront invalidation...`);
                     } else {
                         return invalidateCloudfrontDistribution(this.serverless, invalidationPaths);
@@ -572,6 +560,31 @@ class ServerlessFullstackPlugin {
             stage = this.cliOptions.stage;
         }
         return stage;
+    }
+
+    /**
+     * Serverless v3 hotfix/compat.
+     * @param {the cli option} param 
+     * @returns Boolean
+     */
+    getCLIOptions(param) {
+      // v3
+      const isv3 = this.serverless.version.split('.')[0] === '3';
+      if (isv3) {
+        const cliOptionsParams = Array.isArray(this.cliOptions?.param) ? [...this.cliOptions.param] : [];
+        const cliOptions = {...this.cliOptions}
+
+        // Build key/value cli options from param array
+        cliOptionsParams.forEach((k) => {
+          const key = k.replace('no-', '');
+          const val = !k.includes('no');
+          cliOptions[key] = val;
+        });
+        return cliOptions[param]
+      }
+
+      // v2
+      return this.cliOptions[param]
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-serverless",
-  "version": "0.8.1",
+  "version": "0.8.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-serverless",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Free-form CLI options are deprecated in serverless v3, therefore this plugin does not work anymore.

- Added `cliOptions` getter with v2 backward compatibility
- Untested with v2! (though it should stillbe working seamlessly)